### PR TITLE
feat: only close writers on flush

### DIFF
--- a/src/main/java/com/vinted/flink/bigquery/sink/async/AsyncBigQuerySinkWriter.java
+++ b/src/main/java/com/vinted/flink/bigquery/sink/async/AsyncBigQuerySinkWriter.java
@@ -235,7 +235,7 @@ public class AsyncBigQuerySinkWriter<A> extends AsyncSinkWriter<Rows<A>, StreamR
             try {
                 writer.close();
             } catch (Exception e) {
-                logger.error("Could not close writer", e);
+                logger.error("Could not close unused writer", e);
             }
         }
     }
@@ -243,19 +243,7 @@ public class AsyncBigQuerySinkWriter<A> extends AsyncSinkWriter<Rows<A>, StreamR
     @Override
     public void close() {
         logger.info("Closing BigQuery write stream");
-        try {
-            flush(false);
-            streamMap.values().forEach(stream -> {
-                try {
-                    stream.close();
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-            });
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-
+        streamMap.values().forEach(StreamWriter::close);
     }
 
 

--- a/src/main/java/com/vinted/flink/bigquery/sink/async/AsyncBigQuerySinkWriter.java
+++ b/src/main/java/com/vinted/flink/bigquery/sink/async/AsyncBigQuerySinkWriter.java
@@ -244,7 +244,7 @@ public class AsyncBigQuerySinkWriter<A> extends AsyncSinkWriter<Rows<A>, StreamR
     public void close() {
         logger.info("Closing BigQuery write stream");
         try {
-            flush(true);
+            flush(false);
             streamMap.values().forEach(stream -> {
                 try {
                     stream.close();

--- a/src/test/java/com/vinted/flink/bigquery/AsyncBigQuerySinkTest.java
+++ b/src/test/java/com/vinted/flink/bigquery/AsyncBigQuerySinkTest.java
@@ -65,7 +65,7 @@ public class AsyncBigQuerySinkTest {
 
     @Test
     public void shouldFailAndNotRetryWhenUnknownErrorReceived(@FlinkTest.FlinkParam FlinkTest.PipelineRunner runner, @FlinkTest.FlinkParam MockAsyncProtoClientProvider mockClientProvider) throws Exception {
-        mockClientProvider.givenStreamIsFinalized(stream);
+        mockClientProvider.givenFailingAppendWithStatus(Status.UNKNOWN);
 
         assertThatThrownBy(() -> {
             runner
@@ -76,7 +76,7 @@ public class AsyncBigQuerySinkTest {
         }).isInstanceOf(JobExecutionException.class);
 
 
-        verify(mockClientProvider.getMockProtoWriter(), times(2)).append(any());
+        verify(mockClientProvider.getMockProtoWriter(), times(1)).append(any());
     }
 
     @Test


### PR DESCRIPTION
Closing writer while there are records in flight causes issues. So instead of recreating writer immediately move the to a queue and close them on flush